### PR TITLE
Set Polymer version in bower.json to expected value

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ These dependencies are themselves also listed at the top-level, so you can work 
 tree for a library by carefully examining this diagram.
 
 ```sh
-polymer-cdn#2.3.1 /mnt/c/Users/levi/projects/levi/polymer-cdn
+polymer-cdn#2.3.1
 ├─┬ app-layout#2.0.4
 │ ├─┬ iron-flex-layout#2.0.1
 │ │ └─┬ polymer#2.3.1
@@ -316,7 +316,7 @@ polymer-cdn#2.3.1 /mnt/c/Users/levi/projects/levi/polymer-cdn
 │ ├── iron-resizable-behavior#2.0.1
 │ ├── iron-selector#2.0.1
 │ └── polymer#2.3.1
-├─┬ paper-dropdown-menu#2.0.0
+├─┬ paper-dropdown-menu#2.0.1
 │ ├── iron-a11y-keys-behavior#2.0.1
 │ ├── iron-form-element-behavior#2.0.0
 │ ├── iron-icon#2.0.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# polymer-cdn <sup><sub>v2.0.2</sub></sup>
+# polymer-cdn <sup><sub>v2.3.1</sub></sup>
 **A mirror of Polymer's components so that they can be used directly from CDN**
 
 ![Polymer CDN is powered by MaxCDN](http://i.imgur.com/9obTXpk.png)
@@ -10,7 +10,7 @@
 ## How to use
 In general, given an element named `my-cool-element`, the CDN url for it will be:
 ```
-https://cdn.rawgit.com/download/polymer-cdn/2.0.2/lib/my-cool-element/my-cool-element.html
+https://cdn.rawgit.com/download/polymer-cdn/2.3.1/lib/my-cool-element/my-cool-element.html
 ```
 To be sure, browse this repo and copy-paste the url to the raw version into [RawGit](https://rawgit.com).
 
@@ -49,7 +49,7 @@ which explains it in more detail.
 
 
 ## Contents
-All the libraries available in polymer-cdn can be found side-by-side in the [lib](https://github.com/Download/polymer-cdn/tree/2.0.2/lib) subfolder. Contained therein are all elements [listed as compatible with Polymer 2](https://www.polymer-project.org/2.0/docs/about_20#elements).
+All the libraries available in polymer-cdn can be found side-by-side in the [lib](https://github.com/Download/polymer-cdn/tree/2.3.1/lib) subfolder. Contained therein are all elements [listed as compatible with Polymer 2](https://www.polymer-project.org/2.0/docs/about_20#elements).
 
 > It looks like `gold-zip-input` wasn't actually ported to Polymer 2 yet at the time of writing this, despite being listed as compatible, as witnessed by incompatibility warnings concerning this element in the Bower output at the bottom of this page. Your mileage with this element may vary.
 

--- a/bower.json
+++ b/bower.json
@@ -102,7 +102,7 @@
     "paper-toolbar": "PolymerElements/paper-toolbar#^2.0.0",
     "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.1",
     "platinum-sw": "PolymerElements/platinum-sw#^2.0.0",
-    "polymer": "Polymer/polymer#^2.2.0",
+    "polymer": "Polymer/polymer#^2.3.1",
     "polymerfire": "firebase/polymerfire#^2.2.1",
     "prism-element": "PolymerElements/prism-element#^2.0.1",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.20",

--- a/lib/paper-dropdown-menu/.bower.json
+++ b/lib/paper-dropdown-menu/.bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-dropdown-menu",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An element that works similarly to a native browser select",
   "authors": [
     "The Polymer Authors"
@@ -79,11 +79,11 @@
   "resolutions": {
     "webcomponentsjs": "^1.0.0"
   },
-  "_release": "2.0.0",
+  "_release": "2.0.1",
   "_resolution": {
     "type": "version",
-    "tag": "v2.0.0",
-    "commit": "1d77306c804367449578e5bdb5a1240c5a50485b"
+    "tag": "v2.0.1",
+    "commit": "efd89f99710ebb3e548ce9b82ee00c6b96366842"
   },
   "_source": "https://github.com/PolymerElements/paper-dropdown-menu.git",
   "_target": "^2.0.0",

--- a/lib/paper-dropdown-menu/bower.json
+++ b/lib/paper-dropdown-menu/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-dropdown-menu",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An element that works similarly to a native browser select",
   "authors": [
     "The Polymer Authors"

--- a/lib/paper-dropdown-menu/paper-dropdown-menu-light.html
+++ b/lib/paper-dropdown-menu/paper-dropdown-menu-light.html
@@ -139,9 +139,7 @@ To style it:
         @apply --paper-dropdown-menu-input;
       }
 
-      /* Keep :host-context() to make it work where :dir doesn't exist */
-      :host(:dir(rtl)) #input,
-      :host-context([dir="rtl"]) #input {
+      #input:dir(rtl) {
         padding-right: 0px;
         padding-left: 20px;
       }
@@ -181,9 +179,7 @@ To style it:
         @apply --paper-dropdown-menu-label;
       }
 
-      /* Keep :host-context() to make it work where :dir doesn't exist */
-      :host(:dir(rtl)) label,
-      :host-context([dir="rtl"]) label {
+      label:dir(rtl) {
         padding-right: 0px;
         padding-left: 20px;
       }
@@ -253,9 +249,7 @@ To style it:
         @apply --paper-dropdown-menu-icon;
       }
 
-      /* Keep :host-context() to make it work where :dir doesn't exist */
-      :host(:dir(rtl)) iron-icon,
-      :host-context([dir="rtl"]) iron-icon {
+      iron-icon:dir(rtl) {
         left: 0;
         right: auto;
       }

--- a/lib/polymer/.bower.json
+++ b/lib/polymer/.bower.json
@@ -40,6 +40,6 @@
     "commit": "bc9b8629df0c61e17efb0b440b793be1658bc202"
   },
   "_source": "https://github.com/Polymer/polymer.git",
-  "_target": "^2.2.0",
+  "_target": "^2.3.1",
   "_originalSource": "Polymer/polymer"
 }


### PR DESCRIPTION
Sorry for the second PR so soon @Download!
I noticed I forgot to commit a change to `bower.json` before my last PR.

Changes: 
We should be listing "polymer": "Polymer/polymer#^2.3.1" since it is the current version being used (even though bower will grab something newer if available). This change is effectively a noop for our code but I would like to use the `bower.json` as documentation to some extent if possible.

Apparently [paper-dropdown](https://github.com/PolymerElements/paper-dropdown-menu/tree/v2.0.1) was just updated so I included that.